### PR TITLE
removes bundle to use this plugin in non-ruby projects

### DIFF
--- a/plugin/sass-convert.vim
+++ b/plugin/sass-convert.vim
@@ -1,20 +1,20 @@
 "Sass to Scss:
-command! -bang -range=% -nargs=0 SassToScss :<line1>,<line2>!bundle exec sass-convert --from sass --to scss
+command! -bang -range=% -nargs=0 SassToScss :<line1>,<line2>!sass-convert --from sass --to scss
 
 "Scss to Sass:
-command! -bang -range=% -nargs=0 ScssToSass :<line1>,<line2>!bundle exec sass-convert --from scss --to sass
+command! -bang -range=% -nargs=0 ScssToSass :<line1>,<line2>!sass-convert --from scss --to sass
 
 "Sass to Scss:
-command! -bang -range=% -nargs=0 CssToScss :<line1>,<line2>!bundle exec sass-convert --from css --to scss
+command! -bang -range=% -nargs=0 CssToScss :<line1>,<line2>!sass-convert --from css --to scss
 
 "CSS to Sass:
-command! -bang -range=% -nargs=0 CssToSass :<line1>,<line2>!bundle exec sass-convert --from css --to sass
+command! -bang -range=% -nargs=0 CssToSass :<line1>,<line2>!sass-convert --from css --to sass
 
 "CSS to Scss:
-command! -bang -range=% -nargs=0 CssToScss :<line1>,<line2>!bundle exec sass-convert --from css --to scss
+command! -bang -range=% -nargs=0 CssToScss :<line1>,<line2>!sass-convert --from css --to scss
 
 "Sass to CSS:
-command! -bang -range=% -nargs=0 SassToCss :<line1>,<line2>!bundle exec sass --stdin --style expanded
+command! -bang -range=% -nargs=0 SassToCss :<line1>,<line2>!sass --stdin --style expanded
 
 "Scss to CSS:
-command! -bang -range=% -nargs=0 ScssToCss :<line1>,<line2>!bundle exec sass --stdin --scss --style expanded
+command! -bang -range=% -nargs=0 ScssToCss :<line1>,<line2>!sass --stdin --scss --style expanded


### PR DESCRIPTION
I found this plugin and was super happy, because I often have to convert css to sass.
But I wanted to use it in a node.js project, which does not have a `.bundle`-directory.

In fact I don't see any need to use the bundled sass-gem.
Correct me if I'm wrong
